### PR TITLE
🚨 [702] galaxy tags must contain lowercase letters and digits only,

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
     - 2012R2
     - 2016
   galaxy_tags:
-    - Java
-    - JDK
-    - JRE
-    - Windows
+    - java
+    - jdk
+    - jre
+    - windows


### PR DESCRIPTION
ansible-lint 4.1.0 found an issue in the meta data of your role. That keeps me from linting my larger playbook to the current standard (also implemented on Galaxy).

This PR basically changes the galaxy tags to lowercase to comply.